### PR TITLE
Bump crawl caps for whole-site ingest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Google Chrome for additional headless browser option
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+RUN wget -q -O /usr/share/keyrings/google-chrome.asc https://dl.google.com/linux/linux_signing_key.pub \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.asc] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
     && apt-get update \
     && apt-get install -y google-chrome-stable \
     && rm -rf /var/lib/apt/lists/*
@@ -91,5 +91,5 @@ ENV CRAWL4AI_HEADLESS=true
 # Expose port for HTTP mode (optional)
 EXPOSE 8000
 
-# Default command runs the MCP server
-CMD ["python", "-m", "crawl4ai_mcp.server"]
+# Default command runs the MCP server in HTTP mode
+CMD ["python", "-m", "crawl4ai_mcp.server", "--transport", "streamable-http"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,5 +91,5 @@ ENV CRAWL4AI_HEADLESS=true
 # Expose port for HTTP mode (optional)
 EXPOSE 8000
 
-# Default command runs the MCP server in HTTP mode
-CMD ["python", "-m", "crawl4ai_mcp.server", "--transport", "streamable-http"]
+# Default command runs the MCP server in HTTP mode, binding to 0.0.0.0 for Railway
+CMD ["python", "-m", "crawl4ai_mcp.server", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]

--- a/crawl4ai_mcp/server_tools/crawl_tools.py
+++ b/crawl4ai_mcp/server_tools/crawl_tools.py
@@ -161,8 +161,8 @@ def register_crawl_tools(mcp, get_modules):
     @mcp.tool(annotations=READONLY_ANNOTATIONS)
     async def deep_crawl_site(
         url: Annotated[str, Field(description="Starting URL")],
-        max_depth: Annotated[int, Field(description="Link depth (1-2)")] = 2,
-        max_pages: Annotated[int, Field(description="Max pages (max: 10)")] = 5,
+        max_depth: Annotated[int, Field(description="Link depth (1-10)")] = 2,
+        max_pages: Annotated[int, Field(description="Max pages (max: 1000)")] = 5,
         crawl_strategy: Annotated[str, Field(description="'bfs'|'dfs'|'best_first'")] = "bfs",
         include_external: Annotated[bool, Field(description="Follow external links")] = False,
         url_pattern: Annotated[Optional[str], Field(description="URL filter pattern")] = None,

--- a/crawl4ai_mcp/validators.py
+++ b/crawl4ai_mcp/validators.py
@@ -170,7 +170,7 @@ def validate_summary_length(summary_length: str) -> Optional[Dict[str, Any]]:
 
 def validate_crawl_depth(
     max_depth: int,
-    max_allowed: int = 5
+    max_allowed: int = 10
 ) -> Optional[Dict[str, Any]]:
     """
     Validate crawl depth parameter.
@@ -201,7 +201,7 @@ def validate_crawl_depth(
 
 def validate_max_pages(
     max_pages: int,
-    max_allowed: int = 100
+    max_allowed: int = 1000
 ) -> Optional[Dict[str, Any]]:
     """
     Validate max pages parameter.


### PR DESCRIPTION
## Summary
- `max_pages` hard cap bumped 100 → 1000 in `validate_max_pages`
- `max_depth` hard cap bumped 5 → 10 in `validate_crawl_depth`
- Tool-schema description for `deep_crawl_site` now says \`max: 1000\` and \`1-10\` to match reality (the \"max: 10\" text was only guidance, no Pydantic constraint was enforced there)

## Why
Equinox uses this MCP to ingest full brand sites (~500 pages each) into Sofia's RAG content library. The baked-in caps block that use case without any infra reason.

## Test plan
- [ ] Deploy to Railway (`crawl-mcp-production.up.railway.app`)
- [ ] Call `deep_crawl_site(url='https://designito.com', max_pages=500, max_depth=4)` and confirm it doesn't 400 on the cap
- [ ] Confirm existing small crawls (`max_pages=5`) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)