### PR TITLE
Fix: Handle None values gracefully in .get() calls

### DIFF
--- a/crawl4ai_mcp/middleware/response_transform.py
+++ b/crawl4ai_mcp/middleware/response_transform.py
@@ -57,7 +57,7 @@ def _process_content_fields(
     # Handle content field based on include_cleaned_html flag
     if not include_cleaned_html and 'content' in result_dict:
         # Only remove if markdown is available or generate_markdown is True
-        if generate_markdown and result_dict.get("markdown", "").strip():
+        if generate_markdown and (result_dict.get("markdown") or "").strip():
             del result_dict['content']
             warnings.append(
                 "HTML content removed to save tokens. Use include_cleaned_html=true to include it."

--- a/crawl4ai_mcp/server_helpers.py
+++ b/crawl4ai_mcp/server_helpers.py
@@ -54,9 +54,9 @@ def _should_trigger_fallback(
         return True, f"Initial crawl failed: {error_msg}"
 
     # Check for meaningful content based on what was requested
-    has_markdown = bool(result_dict.get("markdown", "").strip())
-    has_content = bool(result_dict.get("content", "").strip())
-    has_raw_content = bool(result_dict.get("raw_content", "").strip())
+    has_markdown = bool((result_dict.get("markdown") or "").strip())
+    has_content = bool((result_dict.get("content") or "").strip())
+    has_raw_content = bool((result_dict.get("raw_content") or "").strip())
 
     # If markdown was requested but is empty, and no other content exists
     if generate_markdown and not has_markdown:


### PR DESCRIPTION
## Problem

When crawl4ai returns empty/None results, the MCP server crashes with:

```
AttributeError: NoneType object has no attribute strip
```

This happens in response_transform.py line 60 and server_helpers.py where .get(..., empty) returns None instead of empty string, causing .strip() to fail.

## Fix

Replace:
```
result_dict.get(field, empty).strip()
```

With:
```
(result_dict.get(field) or empty).strip()
```

## Changed Files

- crawl4ai_mcp/middleware/response_transform.py (line 60)
- crawl4ai_mcp/server_helpers.py (lines 57-59)

Related: #24

---
*This PR was created automatically by a local AI agent (Hermes Agent).*